### PR TITLE
Introducing Flexibility to Laser on/off Gcodes

### DIFF
--- a/raster2laser_gcode.inx
+++ b/raster2laser_gcode.inx
@@ -82,6 +82,9 @@
 		<_item value="3">No Homing</_item>
 	</param>
 	
+	<param name="laseron" type="string"  gui-text="Laser ON Command">M03</param>
+	<param name="laseroff" type="string"  gui-text="Laser OFF Command">M05</param>
+	
 	<!-- Anteprima = Solo immagine BN -->
 	<param name="preview_only" type="boolean" gui-text="Preview only">false</param>
 	<param name="p_only" type="description">If "Preview only" is true the gcode file will not be generated.</param>

--- a/raster2laser_gcode.py
+++ b/raster2laser_gcode.py
@@ -72,7 +72,11 @@ class GcodeExport(inkex.Effect):
 		# Homing
 		self.OptionParser.add_option("","--homing",action="store", type="int", dest="homing", default="1",help="")
 
-
+		# Commands
+		self.OptionParser.add_option("","--laseron", action="store", type="string", dest="laseron", default="M03", help="")
+		self.OptionParser.add_option("","--laseroff", action="store", type="string", dest="laseroff", default="M05", help="")
+		
+		
 		# Anteprima = Solo immagine BN 
 		self.OptionParser.add_option("","--preview_only",action="store", type="inkbool", dest="preview_only", default=False,help="") 
 
@@ -448,17 +452,17 @@ class GcodeExport(inkex.Effect):
 								if Laser_ON == False :
 									#file_gcode.write('G00 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + ' F' + str(F_G00) + '\n')
 									file_gcode.write('G00 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + '\n') #tolto il Feed sul G00
-									file_gcode.write('M03; Laser ON\n')			
+									file_gcode.write(self.options.laseron + '; Laser ON\n')			
 									Laser_ON = True
 								if  Laser_ON == True :   #DEVO evitare di uscire dalla matrice
 									if x == w-1 :
 										file_gcode.write('G01 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) +' F' + str(F_G01) + '\n')
-										file_gcode.write('M05; Laser OFF\n')
+										file_gcode.write(self.options.laseroff + '; Laser OFF\n')
 										Laser_ON = False
 									else: 
 										if matrice_BN[y][x+1] != N :
 											file_gcode.write('G01 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + ' F' + str(F_G01) +'\n')
-											file_gcode.write('M05; Laser OFF\n')
+											file_gcode.write(self.options.laseroff + '; Laser OFF\n')
 											Laser_ON = False
 					else:
 						for x in reversed(range(w)):
@@ -466,17 +470,17 @@ class GcodeExport(inkex.Effect):
 								if Laser_ON == False :
 									#file_gcode.write('G00 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + ' F' + str(F_G00) + '\n')
 									file_gcode.write('G00 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + '\n') #tolto il Feed sul G00
-									file_gcode.write('M03; Laser ON\n')			
+									file_gcode.write(self.options.laseron + '; Laser ON\n')			
 									Laser_ON = True
 								if  Laser_ON == True :   #DEVO evitare di uscire dalla matrice
 									if x == 0 :
 										file_gcode.write('G01 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) +' F' + str(F_G01) + '\n')
-										file_gcode.write('M05; Laser OFF\n')
+										file_gcode.write(self.options.laseroff + '; Laser OFF\n')
 										Laser_ON = False
 									else: 
 										if matrice_BN[y][x-1] != N :
 											file_gcode.write('G01 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + ' F' + str(F_G01) +'\n')
-											file_gcode.write('M05; Laser OFF\n')
+											file_gcode.write(self.options.laseroff + '; Laser OFF\n')
 											Laser_ON = False				
 
 			else: ##SCALA DI GRIGI
@@ -486,24 +490,24 @@ class GcodeExport(inkex.Effect):
 							if matrice_BN[y][x] != B :
 								if Laser_ON == False :
 									file_gcode.write('G00 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) +'\n')
-									file_gcode.write('M03 '+ ' S' + str(255 - matrice_BN[y][x]) +' ; Laser ON\n')
+									file_gcode.write(self.options.laseron + ' '+ ' S' + str(255 - matrice_BN[y][x]) +' ; Laser ON\n')
 									Laser_ON = True
 									
 								if  Laser_ON == True :   #DEVO evitare di uscire dalla matrice
 									if x == w-1 : #controllo fine riga
 										file_gcode.write('G01 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) +' F' + str(F_G01) + '\n')
-										file_gcode.write('M05; Laser OFF\n')
+										file_gcode.write(self.options.laseroff + '; Laser OFF\n')
 										Laser_ON = False
 										
 									else: 
 										if matrice_BN[y][x+1] == B :
 											file_gcode.write('G01 X' + str(float(x+1)/Scala) + ' Y' + str(float(y)/Scala) + ' F' + str(F_G01) +'\n')
-											file_gcode.write('M05; Laser OFF\n')
+											file_gcode.write(self.options.laseroff + '; Laser OFF\n')
 											Laser_ON = False
 											
 										elif matrice_BN[y][x] != matrice_BN[y][x+1] :
 											file_gcode.write('G01 X' + str(float(x+1)/Scala) + ' Y' + str(float(y)/Scala) + ' F' + str(F_G01) +'\n')
-											file_gcode.write('M03 '+ ' S' + str(255 - matrice_BN[y][x+1]) +' ; Change Laser power\n')												
+											file_gcode.write(self.options.laseron + ' '+ ' S' + str(255 - matrice_BN[y][x+1]) +' ; Change Laser power\n')												
 
 					
 					else:
@@ -511,24 +515,24 @@ class GcodeExport(inkex.Effect):
 							if matrice_BN[y][x] != B :
 								if Laser_ON == False :
 									file_gcode.write('G00 X' + str(float(x+1)/Scala) + ' Y' + str(float(y)/Scala) +'\n')
-									file_gcode.write('M03 '+ ' S' + str(255 - matrice_BN[y][x]) +' ; Laser ON\n')
+									file_gcode.write(self.options.laseron + ' '+ ' S' + str(255 - matrice_BN[y][x]) +' ; Laser ON\n')
 									Laser_ON = True
 									
 								if  Laser_ON == True :   #DEVO evitare di uscire dalla matrice
 									if x == 0 : #controllo fine riga ritorno
 										file_gcode.write('G01 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) +' F' + str(F_G01) + '\n')
-										file_gcode.write('M05; Laser OFF\n')
+										file_gcode.write(self.options.laseroff + '; Laser OFF\n')
 										Laser_ON = False
 										
 									else: 
 										if matrice_BN[y][x-1] == B :
 											file_gcode.write('G01 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + ' F' + str(F_G01) +'\n')
-											file_gcode.write('M05; Laser OFF\n')
+											file_gcode.write(self.options.laseroff + '; Laser OFF\n')
 											Laser_ON = False
 											
 										elif  matrice_BN[y][x] != matrice_BN[y][x-1] :
 											file_gcode.write('G01 X' + str(float(x)/Scala) + ' Y' + str(float(y)/Scala) + ' F' + str(F_G01) +'\n')
-											file_gcode.write('M03 '+ ' S' + str(255 - matrice_BN[y][x-1]) +' ; Change Laser power\n')
+											file_gcode.write(self.options.laseron + ' '+ ' S' + str(255 - matrice_BN[y][x-1]) +' ; Change Laser power\n')
 
 			
 			


### PR DESCRIPTION
With this change the user is able to change the default M03/M05 lasr on/off gcodes on the parameters screen.

With this change 3d printer based diode laser engravers which mainly use the M106/M107 commands for laser on/off may be supported.
