### PR TITLE
Use a more flexible way to detect extensions path (**+ Windows suuport, maybe**)

### DIFF
--- a/raster2laser_gcode.py
+++ b/raster2laser_gcode.py
@@ -26,11 +26,26 @@
 import sys
 import os
 import re
-
-sys.path.append('/usr/share/inkscape/extensions')
-sys.path.append('/Applications/Inkscape.app/Contents/Resources/extensions') 
-
 import subprocess
+
+
+def extensions_path_fallback():
+	sys.path.append('/usr/share/inkscape/extensions')
+	sys.path.append('/Applications/Inkscape.app/Contents/Resources/extensions')
+
+
+try:
+	extensions_path = subprocess.check_output(
+		['inkscape', '--extension-directory']
+	).strip()
+	if extensions_path:
+		sys.path.append(extensions_path)
+	else:
+		extensions_path_fallback()
+except subprocess.CalledProcessError:
+	extensions_path_fallback()
+
+
 import math
 
 import inkex


### PR DESCRIPTION
Hi @oni305, these changes not only make this script workable in terms of a custom extensions' path usage on *nix, but also, I believe, they are moving the script a little bit closer to some multi-platform usage :-)